### PR TITLE
GraphQL queries in Postman

### DIFF
--- a/postman/contentful.postman_collection.json
+++ b/postman/contentful.postman_collection.json
@@ -13,7 +13,7 @@
 					"bearer": [
 						{
 							"key": "token",
-							"value": "5f82882fdae8707fa36c06fe490d4c35074a6d72c3b49f29f70b31e7e214fa2e",
+							"value": "{{cdaToken}}",
 							"type": "string"
 						}
 					]
@@ -55,7 +55,7 @@
 					"bearer": [
 						{
 							"key": "token",
-							"value": "5f82882fdae8707fa36c06fe490d4c35074a6d72c3b49f29f70b31e7e214fa2e",
+							"value": "{{cdaToken}}",
 							"type": "string"
 						}
 					]
@@ -63,9 +63,9 @@
 				"method": "GET",
 				"header": [],
 				"url": {
-					"raw": "{{previewUri}}/spaces/{{spaceId}}/environments/{{environmentId}}/entries?access_token={{cpaToken}}&content_type=topic",
+					"raw": "{{cdaUri}}/spaces/{{spaceId}}/environments/{{environmentId}}/entries?access_token={{cpaToken}}&content_type=topic",
 					"host": [
-						"{{previewUri}}"
+						"{{cdaUri}}"
 					],
 					"path": [
 						"spaces",
@@ -101,7 +101,7 @@
 					"bearer": [
 						{
 							"key": "token",
-							"value": "5f82882fdae8707fa36c06fe490d4c35074a6d72c3b49f29f70b31e7e214fa2e",
+							"value": "{{cdaToken}}",
 							"type": "string"
 						}
 					]
@@ -144,14 +144,14 @@
 			"response": []
 		},
 		{
-			"name": "Get topics of specific category",
+			"name": "Preview - Get topics of specific category",
 			"request": {
 				"auth": {
 					"type": "bearer",
 					"bearer": [
 						{
 							"key": "token",
-							"value": "5f82882fdae8707fa36c06fe490d4c35074a6d72c3b49f29f70b31e7e214fa2e",
+							"value": "{{cdaToken}}",
 							"type": "string"
 						}
 					]
@@ -226,7 +226,7 @@
 					"bearer": [
 						{
 							"key": "token",
-							"value": "5f82882fdae8707fa36c06fe490d4c35074a6d72c3b49f29f70b31e7e214fa2e",
+							"value": "{{cdaToken}}",
 							"type": "string"
 						}
 					]
@@ -272,7 +272,7 @@
 					"bearer": [
 						{
 							"key": "token",
-							"value": "5f82882fdae8707fa36c06fe490d4c35074a6d72c3b49f29f70b31e7e214fa2e",
+							"value": "{{cdaToken}}",
 							"type": "string"
 						}
 					]
@@ -385,7 +385,7 @@
 					"bearer": [
 						{
 							"key": "token",
-							"value": "5f82882fdae8707fa36c06fe490d4c35074a6d72c3b49f29f70b31e7e214fa2e",
+							"value": "{{cdaToken}}",
 							"type": "string"
 						}
 					]
@@ -435,7 +435,7 @@
 					"bearer": [
 						{
 							"key": "token",
-							"value": "5f82882fdae8707fa36c06fe490d4c35074a6d72c3b49f29f70b31e7e214fa2e",
+							"value": "{{cdaToken}}",
 							"type": "string"
 						}
 					]

--- a/postman/contentful.postman_collection.json
+++ b/postman/contentful.postman_collection.json
@@ -1,0 +1,566 @@
+{
+	"info": {
+		"_postman_id": "d0037464-d97e-40b4-b6e8-0cc206034d09",
+		"name": "Contentful REST API calls",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "Get entries of a space",
+			"request": {
+				"auth": {
+					"type": "bearer",
+					"bearer": [
+						{
+							"key": "token",
+							"value": "5f82882fdae8707fa36c06fe490d4c35074a6d72c3b49f29f70b31e7e214fa2e",
+							"type": "string"
+						}
+					]
+				},
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{cdaUri}}/spaces/{{spaceId}}/environments/{{environmentId}}/entries?access_token={{cdaToken}}",
+					"host": [
+						"{{cdaUri}}"
+					],
+					"path": [
+						"spaces",
+						"{{spaceId}}",
+						"environments",
+						"{{environmentId}}",
+						"entries"
+					],
+					"query": [
+						{
+							"key": "access_token",
+							"value": "{{cdaToken}}"
+						},
+						{
+							"key": "Authorization",
+							"value": "",
+							"disabled": true
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get topics",
+			"request": {
+				"auth": {
+					"type": "bearer",
+					"bearer": [
+						{
+							"key": "token",
+							"value": "5f82882fdae8707fa36c06fe490d4c35074a6d72c3b49f29f70b31e7e214fa2e",
+							"type": "string"
+						}
+					]
+				},
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{previewUri}}/spaces/{{spaceId}}/environments/{{environmentId}}/entries?access_token={{cpaToken}}&content_type=topic",
+					"host": [
+						"{{previewUri}}"
+					],
+					"path": [
+						"spaces",
+						"{{spaceId}}",
+						"environments",
+						"{{environmentId}}",
+						"entries"
+					],
+					"query": [
+						{
+							"key": "access_token",
+							"value": "{{cpaToken}}"
+						},
+						{
+							"key": "Authorization",
+							"value": "",
+							"disabled": true
+						},
+						{
+							"key": "content_type",
+							"value": "topic"
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get topics (FR)",
+			"request": {
+				"auth": {
+					"type": "bearer",
+					"bearer": [
+						{
+							"key": "token",
+							"value": "5f82882fdae8707fa36c06fe490d4c35074a6d72c3b49f29f70b31e7e214fa2e",
+							"type": "string"
+						}
+					]
+				},
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{previewUri}}/spaces/{{spaceId}}/environments/{{environmentId}}/entries?access_token={{cpaToken}}&content_type=topic&locale=fr-CA",
+					"host": [
+						"{{previewUri}}"
+					],
+					"path": [
+						"spaces",
+						"{{spaceId}}",
+						"environments",
+						"{{environmentId}}",
+						"entries"
+					],
+					"query": [
+						{
+							"key": "access_token",
+							"value": "{{cpaToken}}"
+						},
+						{
+							"key": "Authorization",
+							"value": "",
+							"disabled": true
+						},
+						{
+							"key": "content_type",
+							"value": "topic"
+						},
+						{
+							"key": "locale",
+							"value": "fr-CA"
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get topics of specific category",
+			"request": {
+				"auth": {
+					"type": "bearer",
+					"bearer": [
+						{
+							"key": "token",
+							"value": "5f82882fdae8707fa36c06fe490d4c35074a6d72c3b49f29f70b31e7e214fa2e",
+							"type": "string"
+						}
+					]
+				},
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{previewUri}}/spaces/{{spaceId}}/environments/{{environmentId}}/entries?access_token={{cpaToken}}&content_type=topic&include=10",
+					"host": [
+						"{{previewUri}}"
+					],
+					"path": [
+						"spaces",
+						"{{spaceId}}",
+						"environments",
+						"{{environmentId}}",
+						"entries"
+					],
+					"query": [
+						{
+							"key": "access_token",
+							"value": "{{cpaToken}}"
+						},
+						{
+							"key": "Authorization",
+							"value": "",
+							"disabled": true
+						},
+						{
+							"key": "content_type",
+							"value": "topic"
+						},
+						{
+							"key": "fields.category.sys.id",
+							"value": "2RxTsjPxpD5ZGSMe1cbNgl",
+							"disabled": true
+						},
+						{
+							"key": "fields.category[all].fields.id",
+							"value": "talent",
+							"disabled": true
+						},
+						{
+							"key": "fields.category.sys.contentType.sys.id",
+							"value": "talent",
+							"disabled": true
+						},
+						{
+							"key": "fields.category.sys.id",
+							"value": "talent",
+							"disabled": true
+						},
+						{
+							"key": "include",
+							"value": "10"
+						},
+						{
+							"key": "fields.category.fields.name[match]",
+							"value": "Talent",
+							"disabled": true
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get categories",
+			"request": {
+				"auth": {
+					"type": "bearer",
+					"bearer": [
+						{
+							"key": "token",
+							"value": "5f82882fdae8707fa36c06fe490d4c35074a6d72c3b49f29f70b31e7e214fa2e",
+							"type": "string"
+						}
+					]
+				},
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{cdaUri}}/spaces/{{spaceId}}/environments/{{environmentId}}/entries?access_token={{cdaToken}}&content_type=category",
+					"host": [
+						"{{cdaUri}}"
+					],
+					"path": [
+						"spaces",
+						"{{spaceId}}",
+						"environments",
+						"{{environmentId}}",
+						"entries"
+					],
+					"query": [
+						{
+							"key": "access_token",
+							"value": "{{cdaToken}}"
+						},
+						{
+							"key": "Authorization",
+							"value": "",
+							"disabled": true
+						},
+						{
+							"key": "content_type",
+							"value": "category"
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get assets of a space",
+			"request": {
+				"auth": {
+					"type": "bearer",
+					"bearer": [
+						{
+							"key": "token",
+							"value": "5f82882fdae8707fa36c06fe490d4c35074a6d72c3b49f29f70b31e7e214fa2e",
+							"type": "string"
+						}
+					]
+				},
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{cdaUri}}/spaces/{{spaceId}}/environments/{{environmentId}}/entries?access_token={{cdaToken}}",
+					"host": [
+						"{{cdaUri}}"
+					],
+					"path": [
+						"spaces",
+						"{{spaceId}}",
+						"environments",
+						"{{environmentId}}",
+						"entries"
+					],
+					"query": [
+						{
+							"key": "access_token",
+							"value": "{{cdaToken}}"
+						},
+						{
+							"key": "Authorization",
+							"value": "",
+							"disabled": true
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get API Keys",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{cmaUri}}/spaces/{{spaceId}}/api_keys?access_token={{cmaToken}}",
+					"host": [
+						"{{cmaUri}}"
+					],
+					"path": [
+						"spaces",
+						"{{spaceId}}",
+						"api_keys"
+					],
+					"query": [
+						{
+							"key": "access_token",
+							"value": "{{cmaToken}}"
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get image",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{imagesUri}}/{{spaceId}}/{{asset_id}}/{{imageToken}}/{{imageFilename}}",
+					"host": [
+						"{{imagesUri}}"
+					],
+					"path": [
+						"{{spaceId}}",
+						"{{asset_id}}",
+						"{{imageToken}}",
+						"{{imageFilename}}"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get scaled image",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{imagesUri}}/{{spaceId}}/{{asset_id}}/{{imageToken}}/{{imageFilename}}?w=300",
+					"host": [
+						"{{imagesUri}}"
+					],
+					"path": [
+						"{{spaceId}}",
+						"{{asset_id}}",
+						"{{imageToken}}",
+						"{{imageFilename}}"
+					],
+					"query": [
+						{
+							"key": "w",
+							"value": "300"
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get cropped image asset",
+			"request": {
+				"auth": {
+					"type": "bearer",
+					"bearer": [
+						{
+							"key": "token",
+							"value": "5f82882fdae8707fa36c06fe490d4c35074a6d72c3b49f29f70b31e7e214fa2e",
+							"type": "string"
+						}
+					]
+				},
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{imagesUri}}/{{spaceId}}/{{asset_id}}/{{imageToken}}/{{imageFilename}}?fit=crop&w=300",
+					"host": [
+						"{{imagesUri}}"
+					],
+					"path": [
+						"{{spaceId}}",
+						"{{asset_id}}",
+						"{{imageToken}}",
+						"{{imageFilename}}"
+					],
+					"query": [
+						{
+							"key": "Authorization",
+							"value": "",
+							"disabled": true
+						},
+						{
+							"key": "",
+							"value": "200",
+							"disabled": true
+						},
+						{
+							"key": "fit",
+							"value": "crop"
+						},
+						{
+							"key": "w",
+							"value": "300"
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get image with rounded corners",
+			"request": {
+				"auth": {
+					"type": "bearer",
+					"bearer": [
+						{
+							"key": "token",
+							"value": "5f82882fdae8707fa36c06fe490d4c35074a6d72c3b49f29f70b31e7e214fa2e",
+							"type": "string"
+						}
+					]
+				},
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{imagesUri}}/{{spaceId}}/{{asset_id}}/{{imageToken}}/{{imageFilename}}?r=90",
+					"host": [
+						"{{imagesUri}}"
+					],
+					"path": [
+						"{{spaceId}}",
+						"{{asset_id}}",
+						"{{imageToken}}",
+						"{{imageFilename}}"
+					],
+					"query": [
+						{
+							"key": "r",
+							"value": "90"
+						},
+						{
+							"key": "Authorization",
+							"value": "",
+							"disabled": true
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "GraphQL Get topics by category",
+			"request": {
+				"auth": {
+					"type": "bearer",
+					"bearer": [
+						{
+							"key": "token",
+							"value": "{{cdaToken}}",
+							"type": "string"
+						}
+					]
+				},
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "graphql",
+					"graphql": {
+						"query": "query {\n    categoryCollection(where: { id: \"talent\"}){\n        items{\n            linkedFrom {\n                topicCollection{\n                    total\n                    items {\n                        name\n                    }\n                }\n            }\n        }\n    }\n}",
+						"variables": ""
+					}
+				},
+				"url": {
+					"raw": "{{graphQLUri}}spaces/{{spaceId}}/environments/{{environmentId}}/",
+					"host": [
+						"{{graphQLUri}}spaces"
+					],
+					"path": [
+						"{{spaceId}}",
+						"environments",
+						"{{environmentId}}",
+						""
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "GraphQL Get topics by category Copy",
+			"request": {
+				"auth": {
+					"type": "bearer",
+					"bearer": [
+						{
+							"key": "token",
+							"value": "{{cdaToken}}",
+							"type": "string"
+						}
+					]
+				},
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "graphql",
+					"graphql": {
+						"query": "query {\n    topicCollection {\n      items {\n        sys {\n          id\n        }\n        name\n        categoryMy: categoryCollection(id: \"talent\")\n        # categoryCollection {\n        #     items {\n        #         name\n        #     }\n        # }\n      }\n    }\n  }\n\n# query {\n#     categoryCollection(where: { id: \"talent\"}) {\n#         items {\n#             topicsCollection {\n#                 items {\n#                     sys{\n#                         id\n#                     }\n#                     name\n#                 }\n#             }\n#         }\n#     }\n# }",
+						"variables": ""
+					}
+				},
+				"url": {
+					"raw": "{{graphQLUri}}spaces/{{spaceId}}/environments/{{environmentId}}/",
+					"host": [
+						"{{graphQLUri}}spaces"
+					],
+					"path": [
+						"{{spaceId}}",
+						"environments",
+						"{{environmentId}}",
+						""
+					]
+				}
+			},
+			"response": []
+		}
+	],
+	"event": [
+		{
+			"listen": "prerequest",
+			"script": {
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		},
+		{
+			"listen": "test",
+			"script": {
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		}
+	]
+}

--- a/postman/contentful.postman_environment.json
+++ b/postman/contentful.postman_environment.json
@@ -1,0 +1,64 @@
+{
+	"id": "c21b29a4-1272-439e-91ce-d75cd26a864b",
+	"name": "Contentful REST API calls",
+	"values": [
+		{
+			"key": "cmaUri",
+			"value": "https://api.contentful.com",
+			"enabled": true
+		},
+		{
+			"key": "cdaUri",
+			"value": "https://cdn.contentful.com",
+			"enabled": true
+		},
+		{
+			"key": "previewUri",
+			"value": "https://preview.contentful.com",
+			"enabled": true
+		},
+		{
+			"key": "spaceId",
+			"value": "zy72kv0qwyyq",
+			"enabled": true
+		},
+		{
+			"key": "environmentId",
+			"value": "master",
+			"enabled": true
+		},
+		{
+			"key": "cmaToken",
+			"value": "",
+			"enabled": false
+		},
+		{
+			"key": "cdaToken",
+			"value": "",
+			"enabled": true
+		},
+		{
+			"key": "cpaToken",
+			"value": "",
+			"enabled": true
+		},
+		{
+			"key": "imagesUri",
+			"value": "https://images.ctfassets.net",
+			"enabled": true
+		},
+		{
+			"key": "content_type_id",
+			"value": "person",
+			"enabled": true
+		},
+		{
+			"key": "previewToken",
+			"value": "",
+			"enabled": true
+		}
+	],
+	"_postman_variable_scope": "environment",
+	"_postman_exported_at": "2022-03-14T20:37:47.037Z",
+	"_postman_exported_using": "Postman/9.14.13"
+}


### PR DESCRIPTION
# Summary | Résumé

Issue #14 Helps keep track of contentful graphql queries in a separate `postman` folder
