### PR TITLE
fix: prevent aws lambda cli from displaying output

### DIFF
--- a/.github/workflows/build_and_push.yml
+++ b/.github/workflows/build_and_push.yml
@@ -69,7 +69,7 @@ jobs:
         run: |
           aws lambda update-function-code \
             --function-name $REPO_NAME \
-            --image-uri $STAGING_REGISTRY/$REPO_NAME:latest
+            --image-uri $STAGING_REGISTRY/$REPO_NAME:latest > /dev/null 2>&1
 
       # - name: Migrate Database
       #   if: matrix.image == 'app'


### PR DESCRIPTION
This PR will prevent the lambda cli commands from dumping their outputs to the workflow logs.