### PR TITLE
feat: a11y scan on new app changes and weekly security scans

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         working-directory: ${{ matrix.folder }}
         run: npm run test
 
-  scan:
+  a11y-scan:
     needs: ci
     name: Run scan websites (a11y)
     uses: cds-snc/scan-websites/.github/workflows/start_scan.yml@main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,3 +51,13 @@ jobs:
       - name: Run tests 🧪
         working-directory: ${{ matrix.folder }}
         run: npm run test
+
+  scan:
+    needs: ci
+    name: Run scan websites (a11y)
+    uses: cds-snc/scan-websites/.github/workflows/start_scan.yml@main
+    with:
+      dynamic: false
+    secrets:
+      scan_websites_key: ${{ secrets.SCAN_WEBSITES_KEY }}
+      scan_websites_template: ${{ secrets.SCAN_WEBSITES_TEMPLATE }}

--- a/.github/workflows/weekly-dynamic-security-scan.yml
+++ b/.github/workflows/weekly-dynamic-security-scan.yml
@@ -5,7 +5,7 @@ on:
   - cron: "0 12 * * 0"
 
 jobs:
-  scan:
+  security-scan:
     name: Run scan websites (security)
     uses: cds-snc/scan-websites/.github/workflows/start_scan.yml@main
     with:

--- a/.github/workflows/weekly-dynamic-security-scan.yml
+++ b/.github/workflows/weekly-dynamic-security-scan.yml
@@ -1,0 +1,15 @@
+name: Scan for security vulnerabilities (Weekly on Sunday)
+
+on:
+  schedule:
+  - cron: "0 12 * * 0"
+
+jobs:
+  scan:
+    name: Run scan websites (security)
+    uses: cds-snc/scan-websites/.github/workflows/start_scan.yml@main
+    with:
+      dynamic: true
+    secrets:
+      scan_websites_key: ${{ secrets.SCAN_WEBSITES_KEY }}
+      scan_websites_template: ${{ secrets.SCAN_WEBSITES_TEMPLATE }}


### PR DESCRIPTION
This PR will onboard this project to [scan-websites](https://scan-websites.alpha.canada.ca/). The worklows being added will trigger a11y scans for each new app deployment, as well as a weekly security scan (Sunday).