### PR TITLE
ci: add contentful json file to storybook build phase

### DIFF
--- a/infrastructure/terragrunt/aws/app/amplify_storybook.tf
+++ b/infrastructure/terragrunt/aws/app/amplify_storybook.tf
@@ -13,6 +13,7 @@ resource "aws_amplify_app" "learning_resources_storybook" {
         preBuild:
           commands:
             - cd app
+            - cp .contentful.json.sample .contentful.json
             - npm install
         build:
           commands:


### PR DESCRIPTION
# Summary | Résumé

Storybook won't build because the build phase is failing at a config error. Copying the contentful config even if it's not used resolves this issue