### PR TITLE
fix: change config to generate html files

### DIFF
--- a/app/nuxt.config.js
+++ b/app/nuxt.config.js
@@ -5,7 +5,6 @@ const i18n = require('./config/i18n.js')
 module.exports = {
   // Target: https://go.nuxtjs.dev/config-target
   target: 'static',
-  ssr: false,
 
   // Global page headers: https://go.nuxtjs.dev/config-head
   head: {


### PR DESCRIPTION
# Summary | Résumé

crawler could not pick up routes when ssr config is set at all
(see: https://nuxtjs.org/announcements/going-full-static/)

# Test instructions | Instructions pour tester la modification

- [ ]  Check that the generate command on amplify picks up the dynamic routes
- [ ] https://learning-resources.cdssandbox.xyz/topic/hiring-talent should load the page