### PR TITLE
Update landing page copy for slightly more context

### DIFF
--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -2,15 +2,15 @@
   "welcome": "Welcome",
   "switch_language": "Français",
   "learning_resources": "Learning Resources",
-  "search_description": "Sharing resources grounded in our work at the Canadian Digital Service to help fellow public servants.",
+  "search_description": "Browse service delivery resources grounded in our work at the Canadian Digital Service.",
   "proof_of_concept": {
     "title": "PILOT",
     "in_progress": "We're testing ideas and working to expand this resource collection."
   },
   "search": "Search",
   "landing_page": {
-    "title": "Welcome to our Learning Resources",
-    "description": "Sharing service delivery resources grounded in our work  at the Canadian Digital Service to help fellow public servants.",
+    "title": "Welcome to CDS Learning Resources",
+    "description": "Browse service delivery resources grounded in our work at the Canadian Digital Service.",
     "slogan": "Service delivery is hard. We can help.",
     "topics_heading": "Topics"
   },

--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -2,15 +2,15 @@
   "welcome": "Welcome",
   "switch_language": "Français",
   "learning_resources": "Learning Resources",
-  "search_description": "Sharing resources grounded in our work to help fellow public servants.",
+  "search_description": "Sharing resources grounded in our work at the Canadian Digital Service to help fellow public servants.",
   "proof_of_concept": {
     "title": "PILOT",
     "in_progress": "We're testing ideas and working to expand this resource collection."
   },
   "search": "Search",
   "landing_page": {
-    "title": "Welcome to CDS Learning Resources",
-    "description": "Sharing service delivery resources grounded in our work to help fellow public servants.",
+    "title": "Welcome to our Learning Resources",
+    "description": "Sharing service delivery resources grounded in our work  at the Canadian Digital Service to help fellow public servants.",
     "slogan": "Service delivery is hard. We can help.",
     "topics_heading": "Topics"
   },

--- a/app/locales/fr.json
+++ b/app/locales/fr.json
@@ -2,14 +2,14 @@
   "welcome": "Bienvenue",
   "switch_language": "English",
   "learning_resources": "Ressources d'apprentissage",
-  "search_description": "Nous partageons des ressources de prestation de services ancrées dans notre travail pour aider nos collègues fonctionnaires.",
+  "search_description": "Nous partageons des ressources de prestation de services ancrées dans notre travail au Service numérique canadien pour aider nos collègues fonctionnaires.",
   "proof_of_concept": {
     "title": "PILOTE",
     "in_progress": "Nous testons des idées et travaillons à l'élargissement de cette collection de ressources."
   },
   "landing_page": {
-    "title": "Bienvenue aux ressources d'apprentissage du SNC",
-    "description": "Nous partageons des ressources de prestation de services ancrées dans notre travail pour aider nos collègues fonctionnaires.",
+    "title": "Bienvenue à nos ressources d'apprentissage",
+    "description": "Nous partageons des ressources de prestation de services ancrées dans notre travail au Service numérique canadien pour aider nos collègues fonctionnaires.",
     "slogan": "La prestation de services est difficile. Nous pouvons vous aider.",
     "topics_heading": "Thèmes"
   },

--- a/app/locales/fr.json
+++ b/app/locales/fr.json
@@ -2,14 +2,14 @@
   "welcome": "Bienvenue",
   "switch_language": "English",
   "learning_resources": "Ressources d'apprentissage",
-  "search_description": "Nous partageons des ressources de prestation de services ancrées dans notre travail au Service numérique canadien pour aider nos collègues fonctionnaires.",
+  "search_description": "Feuilletez des ressources de prestation de services ancrées dans notre travail au Service numérique canadien.",
   "proof_of_concept": {
     "title": "PILOTE",
     "in_progress": "Nous testons des idées et travaillons à l'élargissement de cette collection de ressources."
   },
   "landing_page": {
-    "title": "Bienvenue à nos ressources d'apprentissage",
-    "description": "Nous partageons des ressources de prestation de services ancrées dans notre travail au Service numérique canadien pour aider nos collègues fonctionnaires.",
+    "title": "Bienvenue aux ressources d'apprentissage du SNC",
+    "description": "Feuilletez des ressources de prestation de services ancrées dans notre travail au Service numérique canadien.",
     "slogan": "La prestation de services est difficile. Nous pouvons vous aider.",
     "topics_heading": "Thèmes"
   },


### PR DESCRIPTION
Update copy on homepage to spell out CDS acronym in EN + FR. 

This was done as a result of the logo no longer including the fully spelled-out CDS originally.

Moved CDS to the subtitle/subheading rather than the title/heading to maximize space.