### PR TITLE
feat: add google tag manager

### DIFF
--- a/.github/workflows/tf_apply.yml
+++ b/.github/workflows/tf_apply.yml
@@ -15,6 +15,7 @@ env:
   TF_VAR_contentful_cda_access_token: ${{ secrets.CONTENTFUL_CDA_ACCESS_TOKEN }}
   TF_VAR_gh_access_token: ${{ secrets.GH_ACCESS_TOKEN }}
   TF_VAR_google_analytics_id: ${{ secrets.GOOGLE_ANALYTICS_ID }}
+  TF_VAR_google_tag_manager_id: ${{ secrets.GOOGLE_TAG_MANAGER_ID }}
 
 
 permissions:

--- a/.github/workflows/tf_plan.yml
+++ b/.github/workflows/tf_plan.yml
@@ -12,6 +12,7 @@ env:
   TF_VAR_contentful_cda_access_token: ${{ secrets.CONTENTFUL_CDA_ACCESS_TOKEN }}
   TF_VAR_gh_access_token: ${{ secrets.GH_ACCESS_TOKEN }}
   TF_VAR_google_analytics_id: ${{ secrets.GOOGLE_ANALYTICS_ID }}
+  TF_VAR_google_tag_manager_id: ${{ secrets.GOOGLE_TAG_MANAGER_ID }}
 
 
 permissions:

--- a/app/nuxt.config.js
+++ b/app/nuxt.config.js
@@ -22,6 +22,7 @@ module.exports = {
 
   publicRuntimeConfig: {
     googleAnalyticsID: process.env.GOOGLE_ANALYTICS_ID,
+    googleTagManagerID: process.env.GOOGLE_TAG_MANAGER_ID
   },
 
   privateRuntimeConfig: {

--- a/app/nuxt.config.js
+++ b/app/nuxt.config.js
@@ -36,7 +36,7 @@ module.exports = {
 
   // Plugins to run before rendering page: https://go.nuxtjs.dev/config-plugins
 
-  plugins: ['~/plugins/vue-gtag', '~/plugins/axios'],
+  plugins: ['~/plugins/vue-gtag', '~/plugins/vue-gtm', '~/plugins/axios'],
 
   // Auto import components: https://go.nuxtjs.dev/config-components
   components: true,

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -11,6 +11,7 @@
         "@contentful/rich-text-html-renderer": "^15.13.1",
         "@contentful/rich-text-types": "^15.12.1",
         "@fortawesome/vue-fontawesome": "^2.0.6",
+        "@gtm-support/vue2-gtm": "^1.3.0",
         "@nuxt/content": "^1.14.0",
         "@nuxtjs/axios": "^5.13.6",
         "@nuxtjs/i18n": "^7.2.0",
@@ -2768,6 +2769,22 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.2.tgz",
       "integrity": "sha512-82cpyJyKRoQoRi+14ibCeGPu0CwypgtBAdBhq1WfvagpCZNKqwXbKwXllYSMG91DhmG4jt9gN8eP6lGOtozuaw=="
+    },
+    "node_modules/@gtm-support/core": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@gtm-support/core/-/core-1.3.0.tgz",
+      "integrity": "sha512-+dGzsV9hu4XgtlLmUps+nxWuLmnu57ByZuoExBpc9D6KsZ3Q9gk4dFf7H1TxLqcIOtTW2KlrOtO5hPV5Hoo2JA=="
+    },
+    "node_modules/@gtm-support/vue2-gtm": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@gtm-support/vue2-gtm/-/vue2-gtm-1.3.0.tgz",
+      "integrity": "sha512-yO7+gxSQEEcPH6gWMNcdhRDyj4ApBnG4JHIizP1HfY8y1+8SFNQIWE1icJY8l3wNW6DYVz3wtP+Ri2Wk4aF7Kw==",
+      "dependencies": {
+        "@gtm-support/core": "1.3.0"
+      },
+      "peerDependencies": {
+        "vue": "^2.6.14"
+      }
     },
     "node_modules/@hapi/accept": {
       "version": "5.0.2",
@@ -44795,6 +44812,19 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.2.tgz",
       "integrity": "sha512-82cpyJyKRoQoRi+14ibCeGPu0CwypgtBAdBhq1WfvagpCZNKqwXbKwXllYSMG91DhmG4jt9gN8eP6lGOtozuaw=="
+    },
+    "@gtm-support/core": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@gtm-support/core/-/core-1.3.0.tgz",
+      "integrity": "sha512-+dGzsV9hu4XgtlLmUps+nxWuLmnu57ByZuoExBpc9D6KsZ3Q9gk4dFf7H1TxLqcIOtTW2KlrOtO5hPV5Hoo2JA=="
+    },
+    "@gtm-support/vue2-gtm": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@gtm-support/vue2-gtm/-/vue2-gtm-1.3.0.tgz",
+      "integrity": "sha512-yO7+gxSQEEcPH6gWMNcdhRDyj4ApBnG4JHIizP1HfY8y1+8SFNQIWE1icJY8l3wNW6DYVz3wtP+Ri2Wk4aF7Kw==",
+      "requires": {
+        "@gtm-support/core": "1.3.0"
+      }
     },
     "@hapi/accept": {
       "version": "5.0.2",

--- a/app/package.json
+++ b/app/package.json
@@ -21,6 +21,7 @@
     "@contentful/rich-text-html-renderer": "^15.13.1",
     "@contentful/rich-text-types": "^15.12.1",
     "@fortawesome/vue-fontawesome": "^2.0.6",
+    "@gtm-support/vue2-gtm": "^1.3.0",
     "@nuxt/content": "^1.14.0",
     "@nuxtjs/axios": "^5.13.6",
     "@nuxtjs/i18n": "^7.2.0",

--- a/app/plugins/vue-gtm.js
+++ b/app/plugins/vue-gtm.js
@@ -1,0 +1,15 @@
+import Vue from 'vue'
+import VueGtm from '@gtm-support/vue2-gtm';
+
+/**
+ * @type {import('@nuxt/types').Plugin}
+ */
+export default ({ app, $config: { googleTagManagerID } }) => {
+  Vue.use(
+    VueGtm,
+    {
+      id: googleTagManagerID,
+      vueRouter: app.router
+    }
+  )
+}

--- a/infrastructure/terragrunt/aws/app/amplify.tf
+++ b/infrastructure/terragrunt/aws/app/amplify.tf
@@ -40,6 +40,7 @@ resource "aws_amplify_app" "learning_resources" {
     DOMAIN_FR                   = "fr.learning-resources.cdssandbox.xyz"
     contentful_cda_access_token = var.contentful_cda_access_token
     GOOGLE_ANALYTICS_ID         = var.google_analytics_id
+    GOOGLE_TAG_MANAGER_ID       = var.google_tag_manager_id
   }
 
 

--- a/infrastructure/terragrunt/aws/app/amplify_staging.tf
+++ b/infrastructure/terragrunt/aws/app/amplify_staging.tf
@@ -40,7 +40,7 @@ resource "aws_amplify_app" "learning_resources_staging" {
     DOMAIN_FR                   = "fr.staging.learning-resources.cdssandbox.xyz"
     contentful_cda_access_token = var.contentful_cda_access_token
     GOOGLE_ANALYTICS_ID         = "" # Do not collect data
-    GOOGLE_TAG_MANAGER_ID       = "" # Do not collect data
+    GOOGLE_TAG_MANAGER_ID       = var.google_tag_manager_id
   }
 
 

--- a/infrastructure/terragrunt/aws/app/amplify_staging.tf
+++ b/infrastructure/terragrunt/aws/app/amplify_staging.tf
@@ -40,6 +40,7 @@ resource "aws_amplify_app" "learning_resources_staging" {
     DOMAIN_FR                   = "fr.staging.learning-resources.cdssandbox.xyz"
     contentful_cda_access_token = var.contentful_cda_access_token
     GOOGLE_ANALYTICS_ID         = "" # Do not collect data
+    GOOGLE_TAG_MANAGER_ID       = "" # Do not collect data
   }
 
 

--- a/infrastructure/terragrunt/aws/app/inputs.tf
+++ b/infrastructure/terragrunt/aws/app/inputs.tf
@@ -28,3 +28,8 @@ variable "google_analytics_id" {
   type      = string
   sensitive = true
 }
+
+variable "google_tag_manager_id" {
+  type      = string
+  sensitive = true
+}


### PR DESCRIPTION
# Summary | Résumé
Adds google tag manager script to track metrics at https://tagmanager.google.com/