### PR TITLE
ci: add unsafe inline strict dynamic to support v-if

### DIFF
--- a/customHttp.yml
+++ b/customHttp.yml
@@ -10,4 +10,4 @@ customHeaders:
       - key: 'X-Content-Type-Options'
         value: 'nosniff'
       - key: 'Content-Security-Policy'
-        value: "default-src 'self'; script-src 'self' www.googletagmanager.com; frame-src www.googletagmanager.com; connect-src 'self'; img-src 'self'; style-src 'self'; base-uri 'self'; form-action 'self'"
+        value: "default-src 'self'; script-src 'self' www.googletagmanager.com; frame-src www.googletagmanager.com; connect-src 'self'; img-src 'self'; style-src 'unsafe-inline' https: 'strict-dynamic' 'self'; base-uri 'self'; form-action 'self'"


### PR DESCRIPTION
# Summary | Résumé

CSP throws errors on the usage of `style="display: none"` by vue's `v-if`.

![Screen Shot 2022-08-10 at 1 08 10 PM](https://user-images.githubusercontent.com/916044/184010241-64f83515-7a65-494e-9c59-4144e64357ff.png)


![Screen Shot 2022-08-10 at 1 06 37 PM](https://user-images.githubusercontent.com/916044/184010332-ec956027-04f0-487e-a744-d94600eb1bca.png)

Adding in `unsafe-inline` with the `strict-dynamic` for styles should address the problem and minimize the security risks

