### PR TITLE
PR template in root .github folder

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,25 @@
+## 🔗 Linked issue
+> Link to issue
+
+## ❓ Type of change
+- [ ] 📖 Documentation (updates to the documentation or readme)
+- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
+- [ ] 👌 Enhancement (improving an existing functionality like performance)
+- [ ] ✨ New feature (a non-breaking change that adds functionality)
+- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
+
+## 📚 Description
+> 1-3 sentence description of the changed you're proposing, including a link to
+> a GitHub Issue # or Trello card if applicable.
+
+---
+
+> Description en 1 à 3 phrases de la modification proposée, avec un lien vers le
+> problème (« issue ») GitHub ou la fiche Trello, le cas échéant.
+
+
+## 📝 Checklist
+
+- [ ] I have linked an issue or discussion.
+
+- [ ] I have updated the documentation accordingly.


### PR DESCRIPTION
PR template inside the `PULL_REQUEST_TEMPLATE` folder doesn't seem to work, so let's see if we need to put it in the root `.github` folder