### PR TITLE
ci: add google-analytics.com to the CSP

### DIFF
--- a/customHttp.yml
+++ b/customHttp.yml
@@ -10,4 +10,4 @@ customHeaders:
       - key: 'X-Content-Type-Options'
         value: 'nosniff'
       - key: 'Content-Security-Policy'
-        value: "default-src 'self'; script-src 'self' www.googletagmanager.com; frame-src www.googletagmanager.com; connect-src 'self'; img-src 'self'; style-src 'unsafe-inline' https: 'strict-dynamic' 'self'; base-uri 'self'; form-action 'self'"
+        value: "default-src 'self'; script-src 'self' www.googletagmanager.com www.google-analytics.com; frame-src www.googletagmanager.com www.google-analytics.com; connect-src 'self'; img-src 'self'; style-src 'unsafe-inline' https: 'strict-dynamic' 'self'; base-uri 'self'; form-action 'self'"


### PR DESCRIPTION
## 🔗 Linked issue
#154

## ❓ Type of change
🐞 Bug fix (a non-breaking change that fixes an issue)

## 📚 Description
Our CSP (Content Security Policy) is blocking the google analytics script
![Screen Shot 2022-08-16 at 12 50 41 PM](https://user-images.githubusercontent.com/916044/184972147-face630b-8f0f-43d2-ba26-2bfb8f777079.png)


## 📝 Checklist

- [x] I have linked an issue or discussion.
