### PR TITLE
Adding content security header reporting directive

### DIFF
--- a/customHttp.yml
+++ b/customHttp.yml
@@ -10,4 +10,4 @@ customHeaders:
       - key: 'X-Content-Type-Options'
         value: 'nosniff'
       - key: 'Content-Security-Policy'
-        value: "default-src 'self'; script-src 'self' www.googletagmanager.com www.google-analytics.com; frame-src www.googletagmanager.com www.google-analytics.com; connect-src 'self'; img-src 'self'; style-src 'unsafe-inline' https: 'strict-dynamic' 'self'; base-uri 'self'; form-action 'self'"
+        value: "report-uri https://csp-report-to.security.cdssandbox.xyz/report; default-src 'self'; script-src 'self' www.googletagmanager.com www.google-analytics.com; frame-src www.googletagmanager.com www.google-analytics.com; connect-src 'self'; img-src 'self'; style-src 'unsafe-inline' https: 'strict-dynamic' 'self'; base-uri 'self'; form-action 'self'"


### PR DESCRIPTION
Adding content security header reporting directive to generate a report to the CDS CSP Failures app. The url of the service is https://csp-reports.security.cdssandbox.xyz/

## 🔗 Linked issue
This is linked to github issue #201 

## ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

## 📚 Description
Modified the customHttp.yml file to add the line report-uri https://csp-report-to.security.cdssandbox.xyz/report so that CSP failures will be flagged in the CDS CSP reports website. 

## 📝 Checklist

- [x] I have linked an issue or discussion.

- [ ] I have updated the documentation accordingly.
