### PR TITLE
hot fix: add noindex to prevent search engines from indexing

### DIFF
--- a/app/nuxt.config.js
+++ b/app/nuxt.config.js
@@ -16,6 +16,8 @@ module.exports = {
       { name: 'viewport', content: 'width=device-width, initial-scale=1' },
       { hid: 'description', name: 'description', content: '' },
       { name: 'format-detection', content: 'telephone=no' },
+      // Temporarily removing search engine indexing until we are ready to launch
+      { name: 'robots', content: 'noindex' },
     ],
     link: [{ rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' }],
   },


### PR DESCRIPTION
## 🔗 Linked issue
#273

## ❓ Type of change
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] ✨ New feature (a non-breaking change that adds functionality)

## 📚 Description
Adds no index to prevent search engines from indexing the site (see https://developers.google.com/search/docs/crawling-indexing/block-indexing)

## 📝 Checklist

- [x] I have linked an issue or discussion.

- [x] I have updated the documentation accordingly.
