### PR TITLE
Change "Alpha banner" label for coherence with domain change

### DIFF
--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -4,7 +4,7 @@
   "learning_resources": "Learning resources",
   "search_description": "Browse service delivery resources grounded in our work at the Canadian Digital Service.",
   "proof_of_concept": {
-    "title": "PILOT",
+    "title": "ALPHA",
     "in_progress": "We're testing ideas and working to expand this resource collection."
   },
   "search": "Search",

--- a/app/locales/fr.json
+++ b/app/locales/fr.json
@@ -4,7 +4,7 @@
   "learning_resources": "Ressources d'apprentissage",
   "search_description": "Feuilletez des ressources de prestation de services ancrées dans notre travail au Service numérique canadien.",
   "proof_of_concept": {
-    "title": "PILOTE",
+    "title": "ALPHA",
     "in_progress": "Nous testons des idées et travaillons à l'élargissement de cette collection de ressources."
   },
   "landing_page": {


### PR DESCRIPTION
To not introduce too many different ideas, let's change the label in the phase banner to "Alpha".
This matches the change in domain name, provides some quick context and helps set expectations.
We also now have this term more clearly defined throughout the site.