### PR TITLE
feat: add google fonts to the content security policy

### DIFF
--- a/customHttp.yml
+++ b/customHttp.yml
@@ -10,4 +10,4 @@ customHeaders:
       - key: 'X-Content-Type-Options'
         value: 'nosniff'
       - key: 'Content-Security-Policy'
-        value: "report-uri https://csp-report-to.security.cdssandbox.xyz/report; default-src 'self'; script-src 'self' www.googletagmanager.com www.google-analytics.com; frame-src www.googletagmanager.com www.google-analytics.com; connect-src 'self' www.googletagmanager.com www.google-analytics.com; img-src 'self'; style-src 'unsafe-inline' https: 'strict-dynamic' 'self'; base-uri 'self'; form-action 'self'"
+        value: "report-uri https://csp-report-to.security.cdssandbox.xyz/report; default-src 'self'; script-src 'self' www.googletagmanager.com www.google-analytics.com; frame-src www.googletagmanager.com www.google-analytics.com; connect-src 'self' www.googletagmanager.com www.google-analytics.com; img-src 'self'; style-src 'unsafe-inline' https: 'strict-dynamic' 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; base-uri 'self'; form-action 'self'"


### PR DESCRIPTION
## 🔗 Add google fonts to the content security policy
> [Issue 285](https://github.com/cds-snc/resources-ressources/issues/285)

## ❓ Type of change
- [x] ✨ New feature (a non-breaking change that adds functionality)

## 📚 Description
Adding google fonts to the content security policy. 



## 📝 Checklist

- [x] I have linked an issue or discussion.

