### PR TITLE
fix: missing breadcrumbs on about, contact and legal pages

### DIFF
--- a/app/components/Breadcrumbs.vue
+++ b/app/components/Breadcrumbs.vue
@@ -8,7 +8,6 @@
           :to="localePath(homePath, breadcrumbs.locale)"
           class="font-medium text-xl hover:text-blue-800 hover:underline"
         >
-          <!-- {{ breadcrumbs.locale === 'en' ? 'Home' : 'Accueil' }} -->
           {{ $t('home') }}
         </nuxt-link>
         <font-awesome-icon
@@ -22,18 +21,6 @@
         :key="breadcrumb.name"
         class="whitespace-nowrap"
       >
-        <!-- For dynamic path -->
-        <!-- <nuxt-link
-          :to="
-            localePath({
-              name: 'topic-topic',
-              params: { topic: breadcrumb.urlSlug, name: breadcrumb.name },
-            })
-          "
-          class="font-medium hover:text-blue-800 hover:underline"
-        >-->
-
-        <!-- For full static site -->
         <nuxt-link
           :to="breadcrumb.path"
           class="font-medium text-xl hover:text-blue-800 hover:underline"

--- a/app/pages/about.vue
+++ b/app/pages/about.vue
@@ -1,5 +1,10 @@
 <template>
   <div class="max-w-5xl mb-10">
+    <breadcrumbs
+      :breadcrumbs="breadcrumbs"
+      :current-page-title="aboutPage.title"
+    >
+    </breadcrumbs>
     <r-h1 :heading-text="aboutPage.title" class="my-10"></r-h1>
     <div v-html="richText"></div>
   </div>
@@ -43,6 +48,9 @@ export default {
 
     const i18nLocaleCode = locale.substring(0, 2)
 
+    const breadcrumbs = []
+    breadcrumbs.locale = i18nLocaleCode
+
     const headElement = getHeadElement(aboutPage.title, i18nLocaleCode)
 
     const richText = documentToHtmlString(
@@ -50,7 +58,7 @@ export default {
       richTextRenderOptions()
     )
 
-    return { aboutPage, richText, headElement }
+    return { aboutPage, richText, headElement, breadcrumbs }
   },
 
   head() {

--- a/app/pages/contact.vue
+++ b/app/pages/contact.vue
@@ -1,5 +1,10 @@
 <template>
   <div class="max-w-5xl mb-10">
+    <breadcrumbs
+      :breadcrumbs="breadcrumbs"
+      :current-page-title="contactPage.title"
+    >
+    </breadcrumbs>
     <r-h1 :heading-text="contactPage.title" class="my-10"></r-h1>
     <div v-html="richText"></div>
   </div>
@@ -46,6 +51,9 @@ export default {
 
     const i18nLocaleCode = locale.substring(0, 2)
 
+    const breadcrumbs = []
+    breadcrumbs.locale = i18nLocaleCode
+
     const headElement = getHeadElement(contactPage.title, i18nLocaleCode)
 
     const richText = documentToHtmlString(
@@ -53,7 +61,7 @@ export default {
       richTextRenderOptions()
     )
 
-    return { contactPage, richText, headElement }
+    return { contactPage, richText, headElement, breadcrumbs }
   },
 
   head() {

--- a/app/pages/legal/_legal.vue
+++ b/app/pages/legal/_legal.vue
@@ -3,6 +3,11 @@
 <template>
   <div class="mb-10">
     <div class="max-w-5xl">
+      <breadcrumbs
+        :breadcrumbs="breadcrumbs"
+        :current-page-title="legalPage.title"
+      >
+      </breadcrumbs>
       <r-h1 :heading-text="legalPage.title" class="my-10"></r-h1>
       <div v-html="richText"></div>
     </div>
@@ -44,6 +49,8 @@ export default {
     }
 
     const localeCode = currentLocale.substring(0, 2)
+    const breadcrumbs = []
+    breadcrumbs.locale = localeCode
 
     const headElement = getHeadElement(legalPage.title, localeCode)
 
@@ -70,7 +77,7 @@ export default {
       richTextRenderOptions(currentLocale, legalPage.body?.links)
     )
 
-    return { legalPage, richText, headElement }
+    return { legalPage, richText, headElement, breadcrumbs }
   },
 
   head() {


### PR DESCRIPTION
## 🔗 Linked issue
> #349 

## ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

## 📚 Description
> Show breadcrumbs on 'About', 'Contact', and legal pages 

## 📝 Checklist

- [x] I have linked an issue or discussion.

- [x] I have updated the documentation accordingly.
