### PR TITLE
fix: cmd-to-open resource changes current resource

### DIFF
--- a/app/components/ResourceListItem.vue
+++ b/app/components/ResourceListItem.vue
@@ -1,17 +1,12 @@
 <!-- Component View ================================================================================================-->
 
 <template>
-  <div
-    class="py-5 px-1.5 rounded-2xl mb-4 hover:bg-gray-100 cursor-pointer drop-shadow-2xl -mx-2 w-fit"
-    @click="navigateToResource()"
+  <nuxt-link
+    :to="localePath(resource.path, resource.locale)"
+    class="text-2xl font-medium text-blue-800 underline hover:text-blue-700 inline-block py-5 hover:bg-gray-100 px-1.5 rounded-2xl cursor-pointer mb-4 w-fit -mx-2"
   >
-    <nuxt-link
-      :to="localePath(resource.path, resource.locale)"
-      class="text-2xl font-medium text-blue-800 underline hover:text-blue-700"
-    >
-      {{ resource.title }}
-    </nuxt-link>
-  </div>
+    {{ resource.title }}
+  </nuxt-link>
 </template>
 
 <!-- Component Logic ===============================================================================================-->
@@ -41,16 +36,6 @@ export default {
       dateAdded: String,
       path: String,
       locale: String,
-    },
-  },
-
-  // Methods ----------------------------------------------------------------------------------------------------------
-
-  methods: {
-    navigateToResource() {
-      this.$router.push(
-        this.localePath(this.resource.path, this.resource.locale)
-      )
     },
   },
 }


### PR DESCRIPTION
## 🔗 Linked issue
> #178 

## ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

## 📚 Description
> Fixes issue were "cmd-to-open-resource-in-new-tab" leaves the current page
> Now: cmd-to-open opens resources in new tab without leaving the current page

## 📝 Checklist

- [x] I have linked an issue or discussion.

- [x] I have updated the documentation accordingly.
